### PR TITLE
POC chain based actions

### DIFF
--- a/docs/4-kickstart.md
+++ b/docs/4-kickstart.md
@@ -15,14 +15,19 @@ to do the following.
 use Techworker\IOTA\IOTA;
 use Techworker\IOTA\Node;
 use Techworker\IOTA\DI\IOTAContainer;
+use Techworker\IOTA\RemoteApi\RemoteApi;
+use Techworker\IOTA\ClientApi\ClientApi;
 
 $options = [
     'ccurlPath' => '/srv/ccurl'
 ];
 
 // initializes a new IOTA instance with the built in container and one iota node
+$container = new IOTAContainer($options);
+
 $iota = new IOTA(
-    new IOTAContainer($options), 
+    $container->get(RemoteApi::class),
+    $container->get(ClientApi::class),
     [new Node('http://node01.iotatoken.nl:14265')]
 );
 ```

--- a/examples/explorer/address.php
+++ b/examples/explorer/address.php
@@ -11,7 +11,7 @@ use Techworker\IOTA\Type\Address;
 $iota = include __DIR__.'/bootstrap.php';
 
 /** @var GetBalances\Response $balanceInfos */
-$balanceInfos = $iota->getRemoteApi()->getBalances([new Address($_GET['a'])]);
+$balanceInfos = $iota->getRemoteApi()->getBalances($iota->getNode(), [new Address($_GET['a'])]);
 if ($balanceInfos->isError()) {
     die(print_r($balanceInfos));
 }

--- a/examples/explorer/bootstrap.php
+++ b/examples/explorer/bootstrap.php
@@ -16,9 +16,11 @@ ini_set('display_errors', 1);
 set_time_limit(0);
 require_once __DIR__.'/../../vendor/autoload.php';
 
+use Techworker\IOTA\ClientApi\ClientApi;
 use Techworker\IOTA\DI\IOTAContainer;
 use Techworker\IOTA\IOTA;
 use Techworker\IOTA\Node;
+use Techworker\IOTA\RemoteApi\RemoteApi;
 
 $nodes = [
     new Node('http://service.iotasupport.com:14265'),
@@ -29,4 +31,6 @@ $options = [
     'ccurlPath' => __DIR__.'/../../ccurl',
 ];
 
-return new IOTA(new IOTAContainer($options), $nodes);
+$container = new IOTAContainer($options);
+
+return new IOTA($container->get(RemoteApi::class), $container->get(ClientApi::class), $nodes);

--- a/examples/kitchen_sink/bootstrap.php
+++ b/examples/kitchen_sink/bootstrap.php
@@ -17,9 +17,11 @@ set_time_limit(0);
 require_once __DIR__.'/../../vendor/autoload.php';
 require_once __DIR__.'/functions.php';
 
+use Techworker\IOTA\ClientApi\ClientApi;
 use Techworker\IOTA\DI\IOTAContainer;
 use Techworker\IOTA\IOTA;
 use Techworker\IOTA\Node;
+use Techworker\IOTA\RemoteApi\RemoteApi;
 
 $nodes = [
     new Node('http://node01.iotatoken.nl:14265'),
@@ -33,4 +35,6 @@ $options = [
     'ccurlPath' => __DIR__.'/../../ccurl'
 ];
 
-return new IOTA(new IOTAContainer($options), $nodes);
+$container = new IOTAContainer($options);
+
+return new IOTA($container->get(RemoteApi::class), $container->get(ClientApi::class), $nodes);

--- a/examples/spammer/spammer.php
+++ b/examples/spammer/spammer.php
@@ -11,9 +11,11 @@
 
 namespace Techworker\IOTA\Examples\Spammer;
 
+use Techworker\IOTA\ClientApi\ClientApi;
 use Techworker\IOTA\DI\IOTAContainer;
 use Techworker\IOTA\IOTA;
 use Techworker\IOTA\Node;
+use Techworker\IOTA\RemoteApi\RemoteApi;
 use Techworker\IOTA\Type\Address;
 use Techworker\IOTA\Type\Seed;
 use Techworker\IOTA\Type\Tag;
@@ -39,10 +41,9 @@ $nodes = [
     new Node('http://node05.iotatoken.nl:16265'),
 ];
 
-$iota = new IOTA(
-    new IOTAContainer($options),
-    $nodes
-);
+$container = new IOTAContainer($options);
+
+$iota = new IOTA($container->get(RemoteApi::class), $container->get(ClientApi::class), $nodes);
 
 $seed = '';
 for ($i = 0; $i < 81; ++$i) {

--- a/src/ClientApi/Actions/ActionChain.php
+++ b/src/ClientApi/Actions/ActionChain.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Techworker\IOTA\ClientApi\Actions;
+
+class ActionChain
+{
+    private $actions;
+
+    /**
+     * @param $actions ActionInterface[]
+     */
+    public function __construct(array $actions)
+    {
+        $this->actions = $actions;
+    }
+
+    public function execute(string $actionClassName, array $options = [])
+    {
+        foreach ($this->actions as $action) {
+            if ($action instanceof $actionClassName) {
+                return $action->execute($options);
+            }
+        }
+
+        throw new \RuntimeException(sprintf('No action called "%s" found in ClientApi.', $actionClassName));
+    }
+}

--- a/src/ClientApi/Actions/ActionInterface.php
+++ b/src/ClientApi/Actions/ActionInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Techworker\IOTA\ClientApi\Actions;
+
+interface ActionInterface
+{
+    public function execute(array $options = []);
+}

--- a/src/ClientApi/Actions/BroadcastBundle/Action.php
+++ b/src/ClientApi/Actions/BroadcastBundle/Action.php
@@ -41,14 +41,14 @@ class Action extends AbstractAction
     /**
      * Action constructor.
      *
-     * @param Node                                 $node
-     * @param GetBundle\ActionFactory              $getBundleFactory
+     * @param Node $node
+     * @param GetBundle\ActionFactory $getBundleFactory
      * @param BroadcastTransactions\RequestFactory $broadcastTransactionsFactory
      */
     public function __construct(
         Node $node,
-                                GetBundle\ActionFactory $getBundleFactory,
-                                BroadcastTransactions\RequestFactory $broadcastTransactionsFactory
+        GetBundle\ActionFactory $getBundleFactory,
+        BroadcastTransactions\RequestFactory $broadcastTransactionsFactory
     ) {
         $this->setGetBundleFactory($getBundleFactory);
         $this->setBroadcastTransactionsFactory($broadcastTransactionsFactory);
@@ -111,8 +111,11 @@ class Action extends AbstractAction
      */
     public function serialize(): array
     {
-        return array_merge(parent::serialize(), [
-            'tailTransactionHash' => $this->tailTransactionHash->serialize(),
-        ]);
+        return array_merge(
+            parent::serialize(),
+            [
+                'tailTransactionHash' => $this->tailTransactionHash->serialize(),
+            ]
+        );
     }
 }

--- a/src/ClientApi/Address/GetAddressesAction.php
+++ b/src/ClientApi/Address/GetAddressesAction.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Techworker\IOTA\ClientApi\Address;
+
+use Techworker\IOTA\ClientApi\Actions\ActionInterface;
+use Techworker\IOTA\Type\SecurityLevel;
+use Techworker\IOTA\Type\Seed;
+use Techworker\IOTA\Util\AddressUtil;
+
+class GetAddressesAction implements ActionInterface
+{
+    /**
+     * The seed.
+     *
+     * @var Seed
+     */
+    protected $seed;
+
+    /**
+     * The start index.
+     *
+     * @var int
+     */
+    protected $startIndex = 0;
+
+    /**
+     * The level of security.
+     *
+     * @var SecurityLevel
+     */
+    protected $security;
+
+    /**
+     * A value indicating whether to add a checksum to the addresses.
+     *
+     * @var bool
+     */
+    protected $addChecksum = false;
+
+    /**
+     * Address utility.
+     *
+     * @var AddressUtil
+     */
+    protected $addressUtil;
+
+    /**
+     * The number of addresses to return.
+     *
+     * @var int
+     */
+    protected $amount = 1;
+
+    public function __construct(
+        Seed $seed,
+        SecurityLevel $security,
+        AddressUtil $addressUtil,
+        int $startIndex = 0,
+        bool $addChecksum = false,
+        int $amount = 1
+    ) {
+        $this->seed = $seed;
+        $this->security = $security;
+        $this->startIndex = $startIndex;
+        $this->addressUtil = $addressUtil;
+        $this->addChecksum = $addChecksum;
+        $this->amount = $amount;
+    }
+
+    public function execute(array $options = [])
+    {
+        $result = new Result($this);
+        $index = $this->startIndex; // don't change the state
+
+        for ($i = 0; $i < $this->amount; ++$i) {
+            $trace = new Trace(AddressUtil::class);
+            $trace->start();
+            $address = $this->addressUtil->generateAddress(
+                $this->seed,
+                $index,
+                $this->security,
+                $this->addChecksum
+            );
+            $result->addAddress($address, $index);
+            $result->addChildTrace($trace->stop());
+            ++$index;
+        }
+
+        return $result->finish();
+    }
+}

--- a/src/ClientApi/Address/GetNewAddressAction.php
+++ b/src/ClientApi/Address/GetNewAddressAction.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Techworker\IOTA\ClientApi\Address;
+
+use Techworker\IOTA\ClientApi\Actions\ActionInterface;
+use Techworker\IOTA\Type\SecurityLevel;
+use Techworker\IOTA\Type\Seed;
+use Techworker\IOTA\Util\AddressUtil;
+
+class GetNewAddressAction implements ActionInterface
+{
+    /**
+     * The seed to derive the addresses from.
+     *
+     * @var Seed
+     */
+    private $seed;
+
+    /**
+     * The index to start the generation at.
+     *
+     * @var int
+     */
+    private $startIndex = 0;
+
+    /**
+     * The security level for the generated address.
+     *
+     * @var SecurityLevel
+     */
+    private $security;
+
+    /**
+     * A flag indicating whether to add a checksum to the address or not.
+     *
+     * @var bool
+     */
+    private $addChecksum;
+
+    /**
+     * Address utility to generate an address.
+     *
+     * @var AddressUtil
+     */
+    protected $addressUtil;
+
+    public function __construct(
+        Seed $seed,
+        SecurityLevel $security,
+        AddressUtil $addressUtil,
+        int $startIndex = 1,
+        bool $addChecksum = false
+    ) {
+        $this->seed = $seed;
+        $this->startIndex = $startIndex;
+        $this->security = $security;
+        $this->addChecksum = $addChecksum;
+        $this->addressUtil = $addressUtil;
+    }
+
+    public function execute(array $options = [])
+    {
+        if ($this->startIndex < 0) {
+            throw new \InvalidArgumentException('Invalid Index option provided');
+        }
+
+        $result = new Result($this);
+        $index = $this->startIndex;
+
+        // call findTransactions with each new address to see if the address
+        // was already created - if no transaction is found, return the address.
+        $address = $transactions = null;
+        do {
+            if (isset($address, $transactions)) {
+                // @var Address $address
+                // @var FindTransactions\Response $transactions
+                $result->addPassedAddress($address, $index - 1);
+                $result->addTransactions($address, ...$transactions->getTransactionHashes());
+            }
+
+            $trace = new Trace(AddressUtil::class);
+            $trace->start();
+
+            // generate new address
+            $address = $this->addressUtil->generateAddress(
+                $this->seed,
+                $index,
+                $this->security,
+                $this->addChecksum
+            );
+            $result->addChildTrace($trace->stop());
+
+            // fetch remotely recorded transactions
+            $transactions = $this->findTransactions($this->node, [$address]);
+            $result->addChildTrace($transactions->getTrace());
+            ++$index;
+        } while (\count($transactions->getTransactionHashes()) > 0);
+
+        $result->setAddress($address);
+
+        return $result->finish();
+    }
+}

--- a/src/DI/IOTAContainer.php
+++ b/src/DI/IOTAContainer.php
@@ -40,6 +40,7 @@ use Techworker\IOTA\Cryptography\Keccak384\Korn;
 use Techworker\IOTA\Cryptography\Keccak384\NodeJS;
 use Techworker\IOTA\Cryptography\POW\CCurl;
 use Techworker\IOTA\Cryptography\POW\PowInterface;
+use Techworker\IOTA\IOTA;
 use Techworker\IOTA\RemoteApi\Commands\AddNeighbors;
 use Techworker\IOTA\RemoteApi\Commands\AttachToTangle;
 use Techworker\IOTA\RemoteApi\Commands\BroadcastTransactions;
@@ -209,6 +210,10 @@ class IOTAContainer implements ContainerInterface
 
         $this->entries[BroadcastBundle\ActionFactory::class] = function () {
             return new BroadcastBundle\ActionFactory($this);
+        };
+
+        $this->entries[IOTA::class] = function () use ($options) {
+            return new IOTA($this->get(RemoteApi::class), $this->get(ClientApi::class), $options['nodes']);
         };
     }
 

--- a/src/IOTA.php
+++ b/src/IOTA.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Techworker\IOTA;
 
-use Psr\Container\ContainerInterface;
 use Techworker\IOTA\ClientApi\ClientApi;
-use Techworker\IOTA\DI\IOTAContainer;
 use Techworker\IOTA\RemoteApi\RemoteApi;
 
 /**
@@ -30,73 +28,48 @@ class IOTA
      *
      * @var RemoteApi
      */
-    protected $remoteApi;
+    private $remoteApi;
 
     /**
      * Client api instance.
      *
      * @var ClientApi
      */
-    protected $clientApi;
-
-    /**
-     * The container that holds the factories.
-     *
-     * @var IOTAContainer
-     */
-    protected $container;
+    private $clientApi;
 
     /**
      * A list of remote nodes.
      *
      * @var Node[]
      */
-    protected $nodes;
+    private $nodes;
 
     /**
      * The last used node.
      *
      * @var Node
      */
-    protected $lastUsedNode;
+    private $lastUsedNode;
 
     /**
-     * IOTA constructor.
-     *
-     * @param ContainerInterface $container
-     * @param Node[]             $nodes
+     * @param RemoteApi $remoteApi
+     * @param ClientApi $clientApi
+     * @param Node[]    $nodes
      */
-    public function __construct(ContainerInterface $container, array $nodes = [])
+    public function __construct(RemoteApi $remoteApi, ClientApi $clientApi, array $nodes = [])
     {
-        $this->container = $container;
+        $this->remoteApi = $remoteApi;
+        $this->clientApi = $clientApi;
         $this->nodes = $nodes;
     }
 
-    /**
-     * Gets the remote api instance.
-     *
-     * @return RemoteApi
-     */
     public function getRemoteApi(): RemoteApi
     {
-        if (null === $this->remoteApi) {
-            $this->remoteApi = $this->container->get(RemoteApi::class);
-        }
-
         return $this->remoteApi;
     }
 
-    /**
-     * Gets the client api instance.
-     *
-     * @return ClientApi
-     */
     public function getClientApi(): ClientApi
     {
-        if (null === $this->clientApi) {
-            $this->clientApi = $this->container->get(ClientApi::class);
-        }
-
         return $this->clientApi;
     }
 

--- a/tests/ClientApi/Actions/AbstractActionTest.php
+++ b/tests/ClientApi/Actions/AbstractActionTest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Techworker\IOTA\Tests\ClientApi\Actions;
 
 use PHPUnit\Framework\TestCase;
+use Techworker\IOTA\ClientApi\ClientApi;
 use Techworker\IOTA\IOTA;
 use Techworker\IOTA\Node;
+use Techworker\IOTA\RemoteApi\RemoteApi;
 use Techworker\IOTA\Tests\ClientApiMocks;
 use Techworker\IOTA\Tests\Container;
 use Techworker\IOTA\Tests\DummyData;
@@ -66,7 +68,11 @@ abstract class AbstractActionTest extends TestCase
     {
         DummyData::init();
         $this->container = new Container();
-        $this->iota = new IOTA($this->container, [DummyData::getNode()]);
+        $this->iota = new IOTA(
+            $this->prophesize(RemoteApi::class)->reveal(),
+            $this->prophesize(ClientApi::class)->reveal(),
+            [DummyData::getNode()]
+        );
     }
 
     /**

--- a/tests/ClientApi/Actions/BroadcastBundle/ActionTest.php
+++ b/tests/ClientApi/Actions/BroadcastBundle/ActionTest.php
@@ -25,8 +25,6 @@ class ActionTest extends AbstractActionTest
 {
     public function testSetter()
     {
-
-        $this->markTestSkipped('TODO');
         $action = new BroadcastBundle\Action(
             DummyData::getNode(),
             $this->caMocks->getBundleFactory(),

--- a/tests/ClientApi/Actions/BroadcastBundle/FactoryTest.php
+++ b/tests/ClientApi/Actions/BroadcastBundle/FactoryTest.php
@@ -24,7 +24,6 @@ class FactoryTest extends AbstractActionTest
 {
     public function testFactory()
     {
-        $this->markTestSkipped('TODO');
         $factory = new BroadcastBundle\ActionFactory($this->container);
         static::assertInstanceOf(BroadcastBundle\Action::class, $factory->factory(DummyData::getNode()));
     }

--- a/tests/ClientApi/Address/GetNewAddressActionTest.php
+++ b/tests/ClientApi/Address/GetNewAddressActionTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Techworker\IOTA\ClientApi\Address;
+
+use PHPUnit\Framework\TestCase;
+use Techworker\IOTA\Type\SecurityLevel;
+use Techworker\IOTA\Type\Seed;
+use Techworker\IOTA\Util\AddressUtil;
+
+class GetNewAddressActionTest extends TestCase
+{
+    public function testCreationOfNewAddress()
+    {
+        $seed = new Seed('NOCPLHETMOBRESIC9XBNBOJPEEZZPXHBHQUYKVPSBTKCKETQDMDRFX9DZSEYZSWURXRPEHASLIPQMRDNB');
+
+        $getNewAddressAction = new GetNewAddressAction(
+            $seed,
+            $this->prophesize(SecurityLevel::class)->reveal(),
+            $this->prophesize(AddressUtil::class)
+        );
+
+        
+    }
+}

--- a/tests/IOTATest.php
+++ b/tests/IOTATest.php
@@ -34,7 +34,7 @@ class IOTATest extends TestCase
             'mynode' => new Node('http://myNode'),
         ];
 
-        $iota = new IOTA(new Container(), $nodes);
+        $iota = $this->getIotaInstance($nodes);
 
         static::assertCount(3, $iota->getNodes());
 
@@ -51,20 +51,19 @@ class IOTATest extends TestCase
     {
         $this->expectException(\Exception::class);
 
-        $nodes = [];
-        $iota = new IOTA(new Container(), $nodes);
+        $iota = $this->getIotaInstance();
         $iota->getNode('-1');
     }
 
-    public function testGetRemoteApi()
+    /**
+     * @param Node[] $nodes
+     *
+     * @return IOTA
+     */
+    private function getIotaInstance(array $nodes = []): IOTA
     {
-        $iota = new IOTA(new Container(), []);
-        static::assertInstanceOf(RemoteApi::class, $iota->getRemoteApi());
-    }
-
-    public function testGetClientApi()
-    {
-        $iota = new IOTA(new Container(), []);
-        static::assertInstanceOf(ClientApi::class, $iota->getClientApi());
+        return new IOTA(
+            $this->prophesize(RemoteApi::class)->reveal(), $this->prophesize(ClientApi::class)->reveal(), $nodes
+        );
     }
 }


### PR DESCRIPTION
Here is a try to simplify the Actions. I suggest to remove the Factory logic due the reason, that to container should create instances of several objects. I would put the `ActionChain` in the `IOTA` class and the you are able to execute commands with: `IOTA::client(GetNewAddress::class, $options)`. That means I would make a client method in the IOTA class and use here the Action chain with execute method. I prefer the same Logic with the remote client: `IOTA::remote(RemoteCommand::class, $options)` What do you mean about the idea?