### PR TITLE
Removed duplicate throwOnError calls in traits

### DIFF
--- a/src/RemoteApi/Actions/AddNeighbors/ActionTrait.php
+++ b/src/RemoteApi/Actions/AddNeighbors/ActionTrait.php
@@ -62,6 +62,6 @@ trait ActionTrait
         $request = $this->addNeighborsFactory->factory($node);
         $request->setNeighborUris($neighborUris);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/AttachToTangle/ActionTrait.php
+++ b/src/RemoteApi/Actions/AttachToTangle/ActionTrait.php
@@ -79,6 +79,6 @@ trait ActionTrait
         $request->setBranchTransactionHash($branchTransactionHash);
         $request->setMinWeightMagnitude($minWeightMagnitude);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/BroadcastTransactions/ActionTrait.php
+++ b/src/RemoteApi/Actions/BroadcastTransactions/ActionTrait.php
@@ -65,6 +65,6 @@ trait ActionTrait
         $request = $this->broadcastTransactionsFactory->factory($node);
         $request->setTransactions($transactions);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/FindTransactions/ActionTrait.php
+++ b/src/RemoteApi/Actions/FindTransactions/ActionTrait.php
@@ -79,6 +79,6 @@ trait ActionTrait
         $request->setTags($tags);
         $request->setApprovees($approvees);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetBalances/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetBalances/ActionTrait.php
@@ -68,6 +68,6 @@ trait ActionTrait
         $request->setAddresses($addresses);
         $request->setThreshold($threshold);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetInclusionStates/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetInclusionStates/ActionTrait.php
@@ -69,6 +69,6 @@ trait ActionTrait
         $request->setTransactionHashes($transactionHashes);
         $request->setTips($tips);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetNeighbors/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetNeighbors/ActionTrait.php
@@ -60,6 +60,6 @@ trait ActionTrait
     {
         $request = $this->getNeighborsFactory->factory($node);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetNodeInfo/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetNodeInfo/ActionTrait.php
@@ -60,6 +60,6 @@ trait ActionTrait
     {
         $request = $this->getNodeInfoFactory->factory($node);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetTips/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetTips/ActionTrait.php
@@ -60,6 +60,6 @@ trait ActionTrait
     {
         $request = $this->getTipsFactory->factory($node);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetTransactionsToApprove/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetTransactionsToApprove/ActionTrait.php
@@ -78,6 +78,6 @@ trait ActionTrait
             $request->setReference($reference);
         }
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/GetTrytes/Action.php
+++ b/src/RemoteApi/Actions/GetTrytes/Action.php
@@ -119,7 +119,7 @@ class Action extends AbstractAction
      *
      * @throws Exception
      *
-     * @return AbstractResult|Result
+     * @return Result
      */
     public function execute(): Result
     {

--- a/src/RemoteApi/Actions/GetTrytes/Action.php
+++ b/src/RemoteApi/Actions/GetTrytes/Action.php
@@ -119,7 +119,7 @@ class Action extends AbstractAction
      *
      * @throws Exception
      *
-     * @return Result
+     * @return Result|AbstractResult
      */
     public function execute(): Result
     {

--- a/src/RemoteApi/Actions/GetTrytes/ActionTrait.php
+++ b/src/RemoteApi/Actions/GetTrytes/ActionTrait.php
@@ -63,6 +63,6 @@ trait ActionTrait
         $request = $this->getTrytesFactory->factory($node);
         $request->setTransactionHashes($transactionHashes);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/InterruptAttachingToTangle/ActionTrait.php
+++ b/src/RemoteApi/Actions/InterruptAttachingToTangle/ActionTrait.php
@@ -60,6 +60,6 @@ trait ActionTrait
     {
         $request = $this->interruptAttachingToTangleFactory->factory($node);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/IsTailConsistent/ActionTrait.php
+++ b/src/RemoteApi/Actions/IsTailConsistent/ActionTrait.php
@@ -63,6 +63,6 @@ trait ActionTrait
         $request = $this->isTailConsistentFactory->factory($node);
         $request->setTailTransactionHash($tailTransactionHash);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/RemoveNeighbors/ActionTrait.php
+++ b/src/RemoteApi/Actions/RemoveNeighbors/ActionTrait.php
@@ -63,6 +63,6 @@ trait ActionTrait
         $request = $this->removeNeighborsFactory->factory($node);
         $request->setNeighborUris($neighborUris);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }

--- a/src/RemoteApi/Actions/StoreTransactions/ActionTrait.php
+++ b/src/RemoteApi/Actions/StoreTransactions/ActionTrait.php
@@ -63,6 +63,6 @@ trait ActionTrait
         $request = $this->storeTransactionsFactory->factory($node);
         $request->setTransactions($transactions);
 
-        return $request->execute()->throwOnError();
+        return $request->execute();
     }
 }


### PR DESCRIPTION
The `throwOnError` calls are already done in the requests itself.