### PR TITLE
added "php-http/guzzle6-adapter": "^1.1"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "php-http/async-client-implementation": "^1.0",
         "php-http/httplug": "^1.0",
         "php-http/message-factory": "^1.0",
-        "php-http/discovery": "^1.0"
+        "php-http/discovery": "^1.0",
+        "php-http/guzzle6-adapter": "^1.1"
     },
     "require-dev": {
         "twig/twig": "^2.0",


### PR DESCRIPTION
added "php-http/guzzle6-adapter": "^1.1" to address test error:

There was 1 error:

1) IOTA\Tests\RemoteApi\AttachToTangleTest::testAction
Http\Discovery\NotFoundException: No message factories found. To use Guzzle, Diactoros or Slim Framework factories install php-http/message and the chosen message implementation.

/home/iota/php_libs/client/vendor/php-http/discovery/src/MessageFactoryDiscovery.php:27
/home/iota/php_libs/client/tests/RemoteApi/AttachToTangleTest.php:42

Caused by
Http\Discovery\Exception\DiscoveryFailedException: Could not find resource using any discovery strategy. Find more information at http://docs.php-http.org/en/latest/discovery.html#common-errors
 - Puli Factory is not available