### PR TITLE
Add condition for the key is not existed

### DIFF
--- a/src/Util/TryteUtil.php
+++ b/src/Util/TryteUtil.php
@@ -77,7 +77,7 @@ class TryteUtil
     public static function toTrits(string $tryte): array
     {
         if (!isset(self::TRYTE_TO_TRITS_MAP[$tryte])) {
-            throw new InvalidArgumentException('The key ' . $tryte . ' is not existed.');
+            throw new InvalidArgumentException('Invalid tryte: ' . $tryte);
         }
 
         return self::TRYTE_TO_TRITS_MAP[$tryte];

--- a/src/Util/TryteUtil.php
+++ b/src/Util/TryteUtil.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace IOTA\Util;
 
+use InvalidArgumentException;
+
 class TryteUtil
 {
     /**
@@ -74,6 +76,10 @@ class TryteUtil
      */
     public static function toTrits(string $tryte): array
     {
+        if (!isset(self::TRYTE_TO_TRITS_MAP[$tryte])) {
+            throw new InvalidArgumentException('The key ' . $tryte . ' is not existed.');
+        }
+
         return self::TRYTE_TO_TRITS_MAP[$tryte];
     }
 }

--- a/tests/Util/TryteUtilTest.php
+++ b/tests/Util/TryteUtilTest.php
@@ -15,6 +15,7 @@ namespace IOTA\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
 use IOTA\Util\TryteUtil;
+use InvalidArgumentException;
 
 /**
  * Class TryteUtilTest.
@@ -26,6 +27,13 @@ class TryteUtilTest extends TestCase
         foreach (TryteUtil::TRYTE_TO_TRITS_MAP as $tryte => $expectedTrits) {
             static::assertEquals($expectedTrits, TryteUtil::toTrits((string) $tryte));
         }
+    }
+
+    public function testToTritsWithNonExistedKeyShouldThrowExcpeption()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        TryteUtil::toTrits('non_existed_key');
     }
 
     public function testFromTrits()


### PR DESCRIPTION
- As title, add the condition to check whether the `$tryte` key is existed in `TryteUtil::TRYTE_TO_TRITS_MAP` associate array.

- Add the test for verifying this condition.

It's related to issue #59.